### PR TITLE
exception 'Drupal\Core\Extension\InfoParserException' with message

### DIFF
--- a/simple_oauth.info.yml
+++ b/simple_oauth.info.yml
@@ -1,5 +1,5 @@
 name: Simple OAuth
 type: module
-description: The OAuth 2.0 Authorization Framework: Bearer Token Usage
+description: 'The OAuth 2.0 Authorization Framework: Bearer Token Usage'
 core: 8.x
 package: Authentication


### PR DESCRIPTION
'Unable to parse modules/simple_oauth/simple_oauth.info.yml A
colon cannot be used in an unquoted mapping value at line 3 (near
"description: The OAuth 2.0 Authorization Framework: Bearer Token
Usage").