### PR TITLE
[FEATURE] Display the machine name of permissions.

### DIFF
--- a/src/Entity/Form/AccessTokenResourceForm.php
+++ b/src/Entity/Form/AccessTokenResourceForm.php
@@ -74,7 +74,7 @@ class AccessTokenResourceForm extends EntityForm {
     $permissions_list = [];
     $permission_handler = new PermissionHandler($this->moduleHandler, $this->stringTranslation, $this->controllerResolver);
     foreach ($permission_handler->getPermissions() as $permission => $permission_info) {
-      $permissions_list[$permission] = $permission_info['title'];
+      $permissions_list[$permission] = $permission_info['title'] . " ($permission)";
     }
     $form['permissions'] = [
       '#type' => 'checkboxes',


### PR DESCRIPTION
I think it could be useful to see the permission name when creating resources. It makes easier to search by typing the name in the browser. Also it helps when you have sites in multiple languages and translations make harder to understand what are you granting access.

![selection_237](https://cloud.githubusercontent.com/assets/5313631/19174575/11567706-8c06-11e6-8b2e-d552296d8949.png)
